### PR TITLE
Update rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
-  pre-code-review-checks:
+  build-mmtk-core:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Test mmtk-dev-env
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 jobs:
   pre-code-review-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Test mmtk-dev-env
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  pre-code-review-checks:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build docker image
+        run: |
+          docker build -t mmtk-dev .
+      - name: Build mmtk-core
+        run: |
+          docker run mmtk-dev bash -c "git clone https://github.com/mmtk/mmtk-core.git && cargo build --manifest-path=mmtk-core/Cargo.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  # This workflow will be triggered in the mmtk-core CI to make sure mmtk-core can build with the docker image.
   workflow_dispatch:
 
 jobs:
@@ -18,5 +19,7 @@ jobs:
         run: |
           docker build -t mmtk-dev .
       - name: Build mmtk-core
+        # Build with --manifest-path. If we build under the mmtk-core folder with rust-toolchain, cargo will automatically download the correct
+        # toolchain, and we will not be able to test whether the toolchain used in the dockerfile is correct.
         run: |
           docker run mmtk-dev bash -c "git clone https://github.com/mmtk/mmtk-core.git && cargo build --manifest-path=mmtk-core/Cargo.toml"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,20 @@ RUN apt-get update -y
 #install the required packages
 RUN apt-get install wget curl git python python3 openjdk-8-jdk openjdk-11-jdk ant autoconf bison pkg-config zip unzip build-essential gettext gcc-multilib libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2-dev libfontconfig1-dev libtool -y && apt-get clean
 
+# get rust toolchain version
+RUN wget https://raw.githubusercontent.com/mmtk/mmtk-core/master/rust-toolchain
+
 # install rustup without any default toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 RUN /bin/sh -c ". /root/.cargo/env"
 
 # install our current rust toolchain and std library
 # NOTE: ensure to set the RUSTUP_TOOLCHAIN environment variable
-RUN /root/.cargo/bin/rustup toolchain install nightly-2020-12-20
-RUN /root/.cargo/bin/rustup target add i686-unknown-linux-gnu --toolchain nightly-2020-12-20
+RUN export RUSTUP_TOOLCHAIN=$(cat rust-toolchain) && /root/.cargo/bin/rustup toolchain install $RUSTUP_TOOLCHAIN
+RUN export RUSTUP_TOOLCHAIN=$(cat rust-toolchain) && /root/.cargo/bin/rustup target add i686-unknown-linux-gnu --toolchain $RUSTUP_TOOLCHAIN
 
-ADD root/.bash_profile /root/.bash_profile
+# Add .cargo/bin to PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 ENV HOME /root
 WORKDIR /root

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MMTk Dependencies
 
-This repo provides a docker file which lists the dependencies of [MMTk](https://github.com/mmtk/mmtk-core) and its bindings for [V8](https://github.com/mmtk/mmtk-v8), [OpenJDK](https://github.com/mmtk/mmtk-openjdk) and [JikesRVM](https://github.com/mmtk/mmtk-openjdk).
+This repo provides a docker file which lists the dependencies of [MMTk](https://github.com/mmtk/mmtk-core) and its bindings for [V8](https://github.com/mmtk/mmtk-v8), [OpenJDK](https://github.com/mmtk/mmtk-openjdk) and [JikesRVM](https://github.com/mmtk/mmtk-jikesrvm).
 
 This docker file is based-on the official _Ubuntu-18.04_ (bionic) docker image which can be found [here](https://hub.docker.com/_/ubuntu).
 As the docker is minimal, the docker file may install packages (such as `locales`) which are already included on a standard Ubuntu-18.04 installation.

--- a/root/.bash_profile
+++ b/root/.bash_profile
@@ -1,1 +1,0 @@
-export PATH=/root/.cargo/bin:$PATH


### PR DESCRIPTION
This closes https://github.com/mmtk/mmtk-dev-env/issues/2.
* Fetch `rust-toolchain` file from mmtk-core, and install the specified toolchain in `Docekrfile`.
* Add cargo path to `PATH`
* Add a workflow that test building mmtk-core with the docker image (also can be triggered from mmtk-core to test the building).